### PR TITLE
Fixed link for RSEs in Germany

### DIFF
--- a/groups.md
+++ b/groups.md
@@ -4,7 +4,7 @@ Many institutions are now investing in centralised teams providing Research
 Software Engineering expertise. You may be able to locate a local group via the
 below links:
 
-* [Germany]([https://society-rse.org/community/rse-groups/])
+* [Germany](https://de-rse.org/en/map.html)
 * [Netherlands](https://nl-rse.org/pages/community.html)
 * [UK](https://society-rse.org/community/rse-groups/)
 * [USA](http://us-rse.org/rse-groups/)


### PR DESCRIPTION
The link for RSE groups in Germany seemed to be missing but the UK Society link seemed to be there as a placeholder. Replaced this with the link to the [map on the deRSE site](https://de-rse.org/en/map.html) which while not specifically highlighting RSE groups may help people to find a local or nearby RSE contact.